### PR TITLE
added authentication token

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -8,6 +8,6 @@
     "firebase-functions": "^5.0.0"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   }
 }

--- a/map.js
+++ b/map.js
@@ -143,13 +143,24 @@ require([
         event.preventDefault();
     });
 
-    IdentityManager.registerToken({
-        server: "https://utahdnr.maps.arcgis.com",
-        token: "al_0q5M52-9p2c4ryjT4lUQ..pCaxfaUqNPz8aWd5-C3qaWI3iQnZu2luUycsLTiHwfwCyE8vn-FlRBwzOaHZYJMtiufjnfBUXuxltx2hWLdsJgws-q5m8K0NdZltb4bm2YVNCmxcpM1Nb13ClL88mwNazAgLInsRhVetUok.",
-        userId: "app_GGkPYIo6xMJJUCvM",
-        ssl: true,
-        expires: new Date(Date.now() + 7200 * 1000)
-    });
+    fetch("/api/getToken", { method: "POST" })
+        .then(function(r) { return r.json(); })
+        .then(function(response) {
+            if (response.access_token) {
+                IdentityManager.registerToken({
+                    server: "https://utahdnr.maps.arcgis.com",
+                    token: response.access_token,
+                    userId: "app_GGkPYIo6xMJJUCvM",
+                    ssl: true,
+                    expires: new Date(Date.now() + response.expires_in * 1000)
+                });
+            } else {
+                console.error("Auth token error:", response);
+            }
+        })
+        .catch(function(err) {
+            console.error("Auth token proxy failed:", err);
+        });
 
     // Map
     var map = new Map({


### PR DESCRIPTION
Several changes to add token information to get rid of the ArcGIS Online authentication modal popup.

The app now fetches an ArcGIS token from a Firebase Cloud Function at `/api/getToken`, which mints the token server-side from stored secrets (`ARCGIS_CLIENT_ID` / `ARCGIS_CLIENT_SECRET`) instead of embedding a hardcoded token in `map.js`.

- Server: utahdnr.maps.arcgis.com
- Item URL: https://wetlands.geology.utah.gov/

Note: the ArcGIS Client ID/Secret that were previously pasted here have been removed. Because the secret was exposed publicly, it should be rotated in ArcGIS and the new value stored via `firebase functions:secrets:set`.